### PR TITLE
Op.17 No.2: proofreading

### DIFF
--- a/includes/mazurka-op17-no2-parts.ily
+++ b/includes/mazurka-op17-no2-parts.ily
@@ -106,7 +106,7 @@ rightHandUpper = \relative {
   b8[-. r16 <b c>-.( <b cs>8-. <b d>]-. <b ds>4) |
   e16( g'8-.) r16 fs8(\prall e c b) |
   as8( b c as) \tuplet 3/2 { b fs a } |
-  e16( g'8-.) r16 fs8(\prall e c b) |
+  g16( g'8-.) r16 fs8(\prall e c b) |
   
   \barNumberCheck 65
   as8( b c as) \tuplet 3/2 { b fs a } |


### PR DESCRIPTION
I didn't spend too much time with this first round of proofreading, but I did spot one note issue. Hope this helps!

Measure 64, beat 1, right hand: The first note of the measure should G instead of E.